### PR TITLE
Fixed the template for passing var-files

### DIFF
--- a/partials/var-files.hbs
+++ b/partials/var-files.hbs
@@ -1,3 +1,3 @@
 {{#each var-file}}
--var-file={{camelToSnake @key}}={{{this}}}
+-var-file={{{this}}}
 {{/each}}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -47,6 +47,6 @@ module.exports = {
   },
   validate: {
     checkVariables: false,
-    noColour: false,
+    noColor: false,
   },
 };


### PR DESCRIPTION
Fixed the template for passing var-files which should only parse an array, not key/values