### PR TITLE
Add Terraform v0.12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,29 @@ tf.plan({
 terraform plan -var subscription_id=123 -var tenant_id=abc
 ```
 
+### Lists
+
+Passing a list variable requires some additional preparation. For example:
+
+```js
+const subnetArray = [ 'subnetA', 'subnetB' ]
+const subnetString = subnetArray.length
+  ? `[\\"${subnetArray.join('\\", \\"')}\\"]`
+  : '';
+
+tf.plan({
+  var: {
+    subnets: subnetString
+  }
+});
+```
+
+...will be mapped to the following terraform shell command:
+
+```bash
+terraform plan -var "subnets=[\"subnetA\", \"subnetB\"]"
+```
+
 ## Test
 
 `npm run test`

--- a/example.js
+++ b/example.js
@@ -1,12 +1,20 @@
 /* eslint-disable no-console */
 const Terrajs = require('./src/index');
 
-const tf = new Terrajs({ execute: false });
-console.log(tf.validate());
-console.log(tf.fmt({ check: false, diff: true }));
-console.log(tf.fmt({ check: true, diff: true, dir: 'some/path' }));
-console.log(tf.init({ backendConfig: { key: 'KEYKEYKEY' } }));
-console.log(tf.plan({ var: { environment: 'SP', location: 'westeurope' } }));
-console.log(tf.apply({ var: { environment: 'SP', location: 'westeurope' } }));
-console.log(tf.apply({ var: { environment: 'SP', location: 'westeurope' }, plan: 'terraform.tfplan' }));
-console.log(tf.output({ json: true }));
+const example = async () => {
+  const tf = new Terrajs({ execute: false });
+
+  [
+    await tf.version(),
+    await tf.validate(),
+    await tf.fmt({ check: false, diff: true }),
+    await tf.fmt({ check: true, diff: true, dir: 'some/path' }),
+    await tf.init({ backendConfig: { key: 'KEYKEYKEY' } }),
+    await tf.plan({ var: { environment: 'SP', location: 'westeurope' } }),
+    await tf.apply({ var: { environment: 'SP', location: 'westeurope' } }),
+    await tf.apply({ var: { environment: 'SP', location: 'westeurope' }, plan: 'terraform.tfplan' }),
+    await tf.output({ json: true }),
+  ].forEach(command => console.log(command));
+};
+
+example();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cda0/terrajs",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cda0/terrajs",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "description": "A node interface to terraform",
   "main": "src/index.js",
   "scripts": {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -28,6 +28,8 @@ module.exports = {
     write: true,
     diff: false,
     check: false,
+    noColor: true,
+    recursive: false,
   },
   init: {
     backend: true,
@@ -64,6 +66,7 @@ module.exports = {
   },
   validate: {
     checkVariables: false,
+    json: true,
     noColor: false,
   },
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,7 +17,7 @@ function switchHandlebarHelper(value, opts) {
 }
 
 function caseHandlebarHelper() {
-  /* eslint-disable prefer-rest-params */
+  /* eslint-disable-next-line prefer-rest-params */
   const args = Array.prototype.slice.call(arguments);
   const opts = args.pop();
   const caseValues = args;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,8 +2,48 @@ const camelToKebab = str => str.split(/(?=[A-Z])/).join('-').toLowerCase();
 const camelToSnake = str => str.split(/(?=[A-Z])/).join('_').toLowerCase();
 const includes = (a, b, opts) => (a.includes(b) ? opts.fn(this) : opts.inverse(this));
 
+function ifeq(a, b, opts) {
+  return (a === b) ? opts.fn(this) : opts.inverse(this);
+}
+
+function ifneq(a, b, opts) {
+  return (a !== b) ? opts.fn(this) : opts.inverse(this);
+}
+
+function switchHandlebarHelper(value, opts) {
+  this.switch_value = value;
+  this.switch_break = false;
+  return opts.fn(this);
+}
+
+function caseHandlebarHelper() {
+  /* eslint-disable prefer-rest-params */
+  const args = Array.prototype.slice.call(arguments);
+  const opts = args.pop();
+  const caseValues = args;
+
+  if (this.switch_break || caseValues.indexOf(this.switch_value) === -1) {
+    return '';
+  }
+
+  if (opts.hash.break === true) {
+    this.switch_break = true;
+  }
+
+  return opts.fn(this);
+}
+
+function defaultHandlebarHelper(opts) {
+  return (!this.switch_break ? opts.fn(this) : '');
+}
+
 module.exports = {
   camelToKebab,
   camelToSnake,
   includes,
+  ifeq,
+  ifneq,
+  switchHandlebarHelper,
+  caseHandlebarHelper,
+  defaultHandlebarHelper,
 };

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -2,7 +2,13 @@
 /* eslint-env mocha */
 const assert = require('assert');
 const td = require('testdouble');
-const { camelToKebab, camelToSnake, includes } = require('./helpers');
+const {
+  camelToKebab,
+  camelToSnake,
+  includes,
+  ifeq,
+  ifneq,
+} = require('./helpers');
 
 describe('helpers', () => {
   describe('camelToKebab', () => {
@@ -35,6 +41,46 @@ describe('helpers', () => {
 
     it('should call inverse function if a includes b', () => {
       includes(['a', 'b'], 'c', opts);
+      td.verify(opts.inverse(td.matchers.isA(Object)), { times: 1 });
+    });
+  });
+
+  describe('ifeq', () => {
+    const opts = {};
+    beforeEach(() => {
+      opts.fn = td.function();
+      opts.inverse = td.function();
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call fn function if values match', () => {
+      ifeq('a', 'a', opts);
+      td.verify(opts.fn(td.matchers.isA(Object)), { times: 1 });
+    });
+
+    it('should call inverse function if values do not match', () => {
+      ifeq('a', 'b', opts);
+      td.verify(opts.inverse(td.matchers.isA(Object)), { times: 1 });
+    });
+  });
+
+  describe('ifneq', () => {
+    const opts = {};
+    beforeEach(() => {
+      opts.fn = td.function();
+      opts.inverse = td.function();
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call fn function if values do not match', () => {
+      ifneq('a', 'b', opts);
+      td.verify(opts.fn(td.matchers.isA(Object)), { times: 1 });
+    });
+
+    it('should call inverse function if values match', () => {
+      ifneq('a', 'a', opts);
       td.verify(opts.inverse(td.matchers.isA(Object)), { times: 1 });
     });
   });

--- a/src/integration-0.12.test.js
+++ b/src/integration-0.12.test.js
@@ -4,13 +4,13 @@ const assert = require('assert');
 const td = require('testdouble');
 const Terrajs = require('./index');
 
-describe('integration (Terraform 0.11)', () => {
+describe('integration (Terraform 0.12)', () => {
   let tf;
 
   beforeEach(() => {
     tf = new Terrajs({ execute: false });
     td.replace(tf, 'getTerraformVersion');
-    td.when(tf.getTerraformVersion()).thenReturn('0.11');
+    td.when(tf.getTerraformVersion()).thenReturn('0.12');
   });
 
   afterEach(() => td.reset());
@@ -33,7 +33,7 @@ describe('integration (Terraform 0.11)', () => {
           foo: 'foo1',
           bar: 'bar1',
         },
-      }), 'terraform plan -input=false -lock=true -lock-timeout=0s -module-depth=-1 -no-color -out=terraform -parallelism=10 -refresh=true -state=terraform.tfstate -var foo="foo1" -var bar="bar1"');
+      }), 'terraform plan -input=false -lock=true -lock-timeout=0s -no-color -out=terraform -parallelism=10 -refresh=true -state=terraform.tfstate -var foo="foo1" -var bar="bar1"');
     });
 
     it('should map var files flag', async () => {
@@ -42,13 +42,13 @@ describe('integration (Terraform 0.11)', () => {
           'foo',
           'bar',
         ],
-      }), 'terraform plan -input=false -lock=true -lock-timeout=0s -module-depth=-1 -no-color -out=terraform -parallelism=10 -refresh=true -state=terraform.tfstate -var-file=foo -var-file=bar');
+      }), 'terraform plan -input=false -lock=true -lock-timeout=0s -no-color -out=terraform -parallelism=10 -refresh=true -state=terraform.tfstate -var-file=foo -var-file=bar');
     });
 
     it('should remove no-color', async () => {
       assert.strictEqual(await tf.plan({
         noColor: false,
-      }), 'terraform plan -input=false -lock=true -lock-timeout=0s -module-depth=-1 -out=terraform -parallelism=10 -refresh=true -state=terraform.tfstate');
+      }), 'terraform plan -input=false -lock=true -lock-timeout=0s -out=terraform -parallelism=10 -refresh=true -state=terraform.tfstate');
     });
   });
 });

--- a/src/registerHelpers.js
+++ b/src/registerHelpers.js
@@ -1,8 +1,22 @@
 const Handlebars = require('handlebars');
-const { camelToKebab, camelToSnake, includes } = require('./helpers');
+const {
+  camelToKebab,
+  camelToSnake,
+  includes,
+  ifeq,
+  ifneq,
+  switchHandlebarHelper,
+  caseHandlebarHelper,
+  defaultHandlebarHelper,
+} = require('./helpers');
 
 module.exports = () => {
   Handlebars.registerHelper('camelToKebab', camelToKebab);
   Handlebars.registerHelper('camelToSnake', camelToSnake);
   Handlebars.registerHelper('includes', includes);
+  Handlebars.registerHelper('ifeq', ifeq);
+  Handlebars.registerHelper('ifneq', ifneq);
+  Handlebars.registerHelper('switch', switchHandlebarHelper);
+  Handlebars.registerHelper('case', caseHandlebarHelper);
+  Handlebars.registerHelper('default', defaultHandlebarHelper);
 };

--- a/src/registerHelpers.test.js
+++ b/src/registerHelpers.test.js
@@ -17,6 +17,6 @@ describe('registerHelpers', () => {
 
   it('should call exec with the correct arguments', () => {
     registerHelpers();
-    td.verify(registerHelper(td.matchers.isA(String), td.matchers.isA(Function)), { times: 3 });
+    td.verify(registerHelper(td.matchers.isA(String), td.matchers.isA(Function)), { times: 8 });
   });
 });

--- a/templates/fmt.hbs
+++ b/templates/fmt.hbs
@@ -3,4 +3,8 @@
 {{> write }}
 {{> diff }}
 {{> check }}
+{{#ifeq version '0.12'}}
+{{> no-color }}
+{{> recursive }}
+{{/ifeq}}
 {{dir}}

--- a/templates/output.hbs
+++ b/templates/output.hbs
@@ -1,5 +1,7 @@
 {{command}} output
 {{> state }}
 {{> no-color }}
+{{#ifeq version '0.11'}}
 {{> module }}
+{{/ifeq}}
 {{> json }}

--- a/templates/plan.hbs
+++ b/templates/plan.hbs
@@ -4,7 +4,9 @@
 {{> input }}
 {{> lock }}
 {{> lock-timeout }}
+{{#ifeq version '0.11'}}
 {{> module-depth }}
+{{/ifeq}}
 {{> no-color}}
 {{> out }}
 {{> parallelism }}

--- a/templates/validate.hbs
+++ b/templates/validate.hbs
@@ -1,5 +1,13 @@
 {{command}} validate
+
+{{#switch version}}
+  {{#case "0.12"}}
+{{> json }}
+  {{/case}}
+  {{#case "0.11"}}
 {{> check-variables }}
-{{> no-color }}
 {{> vars }}
 {{> var-files }}
+  {{/case}}
+{{/switch}}
+{{> no-color }}

--- a/templates/version.hbs
+++ b/templates/version.hbs
@@ -1,0 +1,1 @@
+{{command}} -version


### PR DESCRIPTION
Adds support for Terraform v0.12.

* `getTerraformVersion()` function added to retrieve the version from the Terraform binary.
* Adds the `terraform -version` command for completeness
* Templates updated to include/exclude breaking changes between `v0.11` and `v0.12`
* Documentation added to show how to pass list variables
* As this is a breaking change, the version has been bumped to `0.1.0`