### PR TITLE
Disable json output on validate command by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cda0/terrajs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cda0/terrajs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A node interface to terraform",
   "main": "src/index.js",
   "scripts": {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -66,7 +66,7 @@ module.exports = {
   },
   validate: {
     checkVariables: false,
-    json: true,
+    json: false,
     noColor: false,
   },
 };


### PR DESCRIPTION
To maintain consistent behaviour with the previous usage of `validate()`, the `json` parameter needs to be set to `false` by default.