### PR TITLE
Add missing commands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .terraform
+*.backup
 *.tfplan
+*.tfstate
 node_modules
 .nyc_output/
-.idea/
-*.iml

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ A module to help with creating terraform commands.
 - `untaint`
 - `validate`
 - `version`
+- `workspace`
+  - `delete`
+  - `list`
+  - `new`
+  - `select`
+  - `show`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A module to help with creating terraform commands.
 
 - `apply`
 - `fmt`
+- `graph`
 - `import`
 - `init`
 - `output`

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A module to help with creating terraform commands.
 - `init`
 - `output`
 - `plan`
+- `providers`
 - `taint`
 - `untaint`
 - `validate`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A module to help with creating terraform commands.
 - `plan`
 - `providers`
 - `refresh`
+- `show`
 - `taint`
 - `untaint`
 - `validate`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@
 
 A module to help with creating terraform commands.
 
+## Supported Commands
+
+- `apply`
+- `fmt`
+- `import`
+- `init`
+- `output`
+- `plan`
+- `taint`
+- `untaint`
+- `validate`
+- `version`
+
 ## Usage
 
 Terrajs will run terraform commands from the directory pass in with `terraformDir`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A module to help with creating terraform commands.
 - `output`
 - `plan`
 - `providers`
+- `refresh`
 - `taint`
 - `untaint`
 - `validate`

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A module to help with creating terraform commands.
 
 - `apply`
 - `fmt`
+- `get`
 - `graph`
 - `import`
 - `init`

--- a/example.js
+++ b/example.js
@@ -11,6 +11,7 @@ const example = async () => {
     await tf.fmt({ check: true, diff: true, dir: 'some/path' }),
     await tf.graph({ drawCycles: true, type: 'plan', dir: 'some/path' }),
     await tf.providers({ dir: 'some/path' }),
+    await tf.show({ moduleDepth: 5 }),
     await tf.init({ backendConfig: { key: 'KEYKEYKEY' } }),
     await tf.import({ address: 'a_resource.exmple', id: '/unique/identifier' }),
     await tf.refresh({ var: { environment: 'SP' }, target: ['a_resource.example'] }),

--- a/example.js
+++ b/example.js
@@ -22,6 +22,12 @@ const example = async () => {
     await tf.output({ json: true }),
     await tf.taint({ resource: 'resource' }),
     await tf.untaint({ resource: 'resource' }),
+
+    await tf.workspaceDelete({ name: 'dev' }),
+    await tf.workspaceList({ dir: 'some/path' }),
+    await tf.workspaceNew({ name: 'dev' }),
+    await tf.workspaceSelect({ name: 'dev' }),
+    await tf.workspaceShow(),
   ].forEach(command => console.log(command));
 };
 

--- a/example.js
+++ b/example.js
@@ -13,6 +13,7 @@ const example = async () => {
     await tf.providers({ dir: 'some/path' }),
     await tf.init({ backendConfig: { key: 'KEYKEYKEY' } }),
     await tf.import({ address: 'a_resource.exmple', id: '/unique/identifier' }),
+    await tf.refresh({ var: { environment: 'SP' }, target: ['a_resource.example'] }),
     await tf.plan({ var: { environment: 'SP', location: 'westeurope' } }),
     await tf.apply({ var: { environment: 'SP', location: 'westeurope' } }),
     await tf.apply({ var: { environment: 'SP', location: 'westeurope' }, plan: 'terraform.tfplan' }),

--- a/example.js
+++ b/example.js
@@ -10,6 +10,7 @@ const example = async () => {
     await tf.fmt({ check: false, diff: true }),
     await tf.fmt({ check: true, diff: true, dir: 'some/path' }),
     await tf.graph({ drawCycles: true, type: 'plan', dir: 'some/path' }),
+    await tf.providers({ dir: 'some/path' }),
     await tf.init({ backendConfig: { key: 'KEYKEYKEY' } }),
     await tf.import({ address: 'a_resource.exmple', id: '/unique/identifier' }),
     await tf.plan({ var: { environment: 'SP', location: 'westeurope' } }),

--- a/example.js
+++ b/example.js
@@ -13,6 +13,7 @@ const example = async () => {
     await tf.providers({ dir: 'some/path' }),
     await tf.show({ moduleDepth: 5 }),
     await tf.init({ backendConfig: { key: 'KEYKEYKEY' } }),
+    await tf.get({ update: true, dir: 'some/path' }),
     await tf.import({ address: 'a_resource.exmple', id: '/unique/identifier' }),
     await tf.refresh({ var: { environment: 'SP' }, target: ['a_resource.example'] }),
     await tf.plan({ var: { environment: 'SP', location: 'westeurope' } }),

--- a/example.js
+++ b/example.js
@@ -10,6 +10,7 @@ const example = async () => {
     await tf.fmt({ check: false, diff: true }),
     await tf.fmt({ check: true, diff: true, dir: 'some/path' }),
     await tf.init({ backendConfig: { key: 'KEYKEYKEY' } }),
+    await tf.import({ address: 'a_resource.exmple', id: '/unique/identifier' }),
     await tf.plan({ var: { environment: 'SP', location: 'westeurope' } }),
     await tf.apply({ var: { environment: 'SP', location: 'westeurope' } }),
     await tf.apply({ var: { environment: 'SP', location: 'westeurope' }, plan: 'terraform.tfplan' }),

--- a/example.js
+++ b/example.js
@@ -9,6 +9,7 @@ const example = async () => {
     await tf.validate(),
     await tf.fmt({ check: false, diff: true }),
     await tf.fmt({ check: true, diff: true, dir: 'some/path' }),
+    await tf.graph({ drawCycles: true, type: 'plan', dir: 'some/path' }),
     await tf.init({ backendConfig: { key: 'KEYKEYKEY' } }),
     await tf.import({ address: 'a_resource.exmple', id: '/unique/identifier' }),
     await tf.plan({ var: { environment: 'SP', location: 'westeurope' } }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,9 +120,9 @@
       }
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1070,9 +1070,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+      "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -2755,9 +2755,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+      "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
       "optional": true,
       "requires": {
         "commander": "~2.20.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cda0/terrajs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cda0/terrajs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A node interface to terraform",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "deepmerge": "^3.2.0",
-    "handlebars": "^4.5.1",
+    "handlebars": "^4.7.3",
     "shelljs": "^0.8.3"
   },
   "devDependencies": {

--- a/partials/allow-missing-config.hbs
+++ b/partials/allow-missing-config.hbs
@@ -1,0 +1,3 @@
+{{#if allowMissingConfig}}
+-allow-missing-config
+{{/if}}

--- a/partials/config.hbs
+++ b/partials/config.hbs
@@ -1,0 +1,3 @@
+{{#if config}}
+-config={{{config}}}
+{{/if}}

--- a/partials/destroy.hbs
+++ b/partials/destroy.hbs
@@ -1,3 +1,3 @@
 {{#if destroy}}
- -destroy
+-destroy
 {{/if}}

--- a/partials/detailed-exit-code.hbs
+++ b/partials/detailed-exit-code.hbs
@@ -1,3 +1,3 @@
 {{#if detailedExitCode}}
- -detailed-exit-code
+-detailed-exit-code
 {{/if}}

--- a/partials/draw-cycles.hbs
+++ b/partials/draw-cycles.hbs
@@ -1,0 +1,3 @@
+{{#if drawCycles}}
+-draw-cycles
+{{/if}}

--- a/partials/force.hbs
+++ b/partials/force.hbs
@@ -1,0 +1,1 @@
+-force={{{force}}}

--- a/partials/provider.hbs
+++ b/partials/provider.hbs
@@ -1,0 +1,3 @@
+{{#if provider}}
+-provider={{{provider}}}
+{{/if}}

--- a/partials/state.hbs
+++ b/partials/state.hbs
@@ -3,5 +3,7 @@
 -state={{{state}}}
   {{/includes}}
 {{else}}
+  {{#if state}}
 -state={{{state}}}
+  {{/if}}
 {{/if}}

--- a/partials/type.hbs
+++ b/partials/type.hbs
@@ -1,0 +1,3 @@
+{{#if type}}
+-type={{{type}}}
+{{/if}}

--- a/partials/update.hbs
+++ b/partials/update.hbs
@@ -1,0 +1,1 @@
+-update={{{update}}}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -45,6 +45,16 @@ module.exports = {
     upgrade: false,
     verifyPlugins: true,
   },
+  import: {
+    backup: 'terraform.backup',
+    allowMissingConfig: false,
+    input: false,
+    lock: true,
+    lockTimeout: 0,
+    noColor: true,
+    state: 'terraform.tfstate',
+    stateOut: null,
+  },
   output: {
     state: 'terraform.tfstate',
     noColor: true,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -31,6 +31,10 @@ module.exports = {
     noColor: true,
     recursive: false,
   },
+  get: {
+    update: false,
+    noColor: true,
+  },
   graph: {
     drawCycles: true,
     moduleDepth: -1,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -31,6 +31,11 @@ module.exports = {
     noColor: true,
     recursive: false,
   },
+  graph: {
+    drawCycles: true,
+    moduleDepth: -1,
+    noColor: true,
+  },
   init: {
     backend: true,
     backendConfig: {},

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -81,6 +81,15 @@ module.exports = {
   },
   providers: {
   },
+  refresh: {
+    backup: 'terraform.backup',
+    input: false,
+    lock: true,
+    lockTimeout: 0,
+    noColor: true,
+    state: 'terraform.tfstate',
+    dir: '',
+  },
   validate: {
     checkVariables: false,
     json: false,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -120,4 +120,24 @@ module.exports = {
     json: false,
     noColor: false,
   },
+  'workspace-delete': {
+    force: false,
+    lock: true,
+    lockTimeout: 0,
+    dir: '',
+  },
+  'workspace-list': {
+    dir: '',
+  },
+  'workspace-new': {
+    lock: true,
+    lockTimeout: 0,
+    state: '',
+    dir: '',
+  },
+  'workspace-select': {
+    dir: '',
+  },
+  'workspace-show': {
+  },
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -98,11 +98,6 @@ module.exports = {
     moduleDepth: -1,
     noColor: true,
   },
-  validate: {
-    checkVariables: false,
-    json: false,
-    noColor: false,
-  },
   taint: {
     allowMissing: false,
     backup: 'terraform.backup',
@@ -119,5 +114,10 @@ module.exports = {
     noColor: true,
     state: 'terraform.tfstate',
     stateOut: null,
+  },
+  validate: {
+    checkVariables: false,
+    json: false,
+    noColor: false,
   },
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -90,6 +90,10 @@ module.exports = {
     state: 'terraform.tfstate',
     dir: '',
   },
+  show: {
+    moduleDepth: -1,
+    noColor: true,
+  },
   validate: {
     checkVariables: false,
     json: false,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -79,6 +79,8 @@ module.exports = {
     state: 'terraform.tfstate',
     plan: '',
   },
+  providers: {
+  },
   validate: {
     checkVariables: false,
     json: false,

--- a/src/index.js
+++ b/src/index.js
@@ -62,6 +62,10 @@ class Terrajs {
     return this.execute ? this.buildAndExec('init', args) : this.buildCommand('init', args);
   }
 
+  import(args = {}) {
+    return this.execute ? this.buildAndExec('import', args) : this.buildCommand('import', args);
+  }
+
   output(args = {}) {
     return this.execute ? this.buildAndExec('output', args) : this.buildCommand('output', args);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,10 @@ class Terrajs {
     return this.execute ? this.buildAndExec('providers', args) : this.buildCommand('providers', args);
   }
 
+  refresh(args = {}) {
+    return this.execute ? this.buildAndExec('refresh', args) : this.buildCommand('refresh', args);
+  }
+
   validate(args = {}) {
     return this.execute ? this.buildAndExec('validate', args) : this.buildCommand('validate', args);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,26 @@ class Terrajs {
   version(args = {}) {
     return this.execute ? this.buildAndExec('version', args) : this.buildCommand('version', args);
   }
+
+  workspaceDelete(args = {}) {
+    return this.execute ? this.buildAndExec('workspace-delete', args) : this.buildCommand('workspace-delete', args);
+  }
+
+  workspaceList(args = {}) {
+    return this.execute ? this.buildAndExec('workspace-list', args) : this.buildCommand('workspace-list', args);
+  }
+
+  workspaceNew(args = {}) {
+    return this.execute ? this.buildAndExec('workspace-new', args) : this.buildCommand('workspace-new', args);
+  }
+
+  workspaceSelect(args = {}) {
+    return this.execute ? this.buildAndExec('workspace-select', args) : this.buildCommand('workspace-select', args);
+  }
+
+  workspaceShow(args = {}) {
+    return this.execute ? this.buildAndExec('workspace-show', args) : this.buildCommand('workspace-show', args);
+  }
 }
 
 module.exports = Terrajs;

--- a/src/index.js
+++ b/src/index.js
@@ -94,20 +94,20 @@ class Terrajs {
     return this.execute ? this.buildAndExec('show', args) : this.buildCommand('show', args);
   }
 
-  validate(args = {}) {
-    return this.execute ? this.buildAndExec('validate', args) : this.buildCommand('validate', args);
-  }
-
-  version(args = {}) {
-    return this.execute ? this.buildAndExec('version', args) : this.buildCommand('version', args);
-  }
-
   taint(args = {}) {
     return this.execute ? this.buildAndExec('taint', args) : this.buildCommand('taint', args);
   }
 
   untaint(args = {}) {
     return this.execute ? this.buildAndExec('untaint', args) : this.buildCommand('untaint', args);
+  }
+
+  validate(args = {}) {
+    return this.execute ? this.buildAndExec('validate', args) : this.buildCommand('validate', args);
+  }
+
+  version(args = {}) {
+    return this.execute ? this.buildAndExec('version', args) : this.buildCommand('version', args);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,10 @@ class Terrajs {
     return this.execute ? this.buildAndExec('fmt', args) : this.buildCommand('fmt', args);
   }
 
+  get(args = {}) {
+    return this.execute ? this.buildAndExec('get', args) : this.buildCommand('get', args);
+  }
+
   graph(args = {}) {
     return this.execute ? this.buildAndExec('graph', args) : this.buildCommand('graph', args);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,10 @@ class Terrajs {
     return this.execute ? this.buildAndExec('plan', args) : this.buildCommand('plan', args);
   }
 
+  providers(args = {}) {
+    return this.execute ? this.buildAndExec('providers', args) : this.buildCommand('providers', args);
+  }
+
   validate(args = {}) {
     return this.execute ? this.buildAndExec('validate', args) : this.buildCommand('validate', args);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,10 @@ class Terrajs {
     return this.execute ? this.buildAndExec('refresh', args) : this.buildCommand('refresh', args);
   }
 
+  show(args = {}) {
+    return this.execute ? this.buildAndExec('show', args) : this.buildCommand('show', args);
+  }
+
   validate(args = {}) {
     return this.execute ? this.buildAndExec('validate', args) : this.buildCommand('validate', args);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,10 @@ class Terrajs {
     return this.execute ? this.buildAndExec('fmt', args) : this.buildCommand('fmt', args);
   }
 
+  graph(args = {}) {
+    return this.execute ? this.buildAndExec('graph', args) : this.buildCommand('graph', args);
+  }
+
   init(args = {}) {
     return this.execute ? this.buildAndExec('init', args) : this.buildCommand('init', args);
   }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -419,6 +419,35 @@ describe('index', () => {
     });
   });
 
+  describe('refresh', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.refresh();
+      td.verify(buildCommand('refresh', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.refresh();
+      td.verify(buildAndExec('refresh', {}));
+    });
+  });
+
   describe('validate', () => {
     let Terrajs;
     let tf;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -390,6 +390,35 @@ describe('index', () => {
     });
   });
 
+  describe('providers', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.providers();
+      td.verify(buildCommand('providers', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.providers();
+      td.verify(buildAndExec('providers', {}));
+    });
+  });
+
   describe('validate', () => {
     let Terrajs;
     let tf;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -448,6 +448,35 @@ describe('index', () => {
     });
   });
 
+  describe('show', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.show();
+      td.verify(buildCommand('show', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.show();
+      td.verify(buildAndExec('show', {}));
+    });
+  });
+
   describe('validate', () => {
     let Terrajs;
     let tf;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -245,6 +245,35 @@ describe('index', () => {
     });
   });
 
+  describe('get', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.get();
+      td.verify(buildCommand('get', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.get();
+      td.verify(buildAndExec('get', {}));
+    });
+  });
+
   describe('graph', () => {
     let Terrajs;
     let tf;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -274,6 +274,35 @@ describe('index', () => {
     });
   });
 
+  describe('import', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.import();
+      td.verify(buildCommand('import', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.import();
+      td.verify(buildAndExec('import', {}));
+    });
+  });
+
   describe('output', () => {
     let Terrajs;
     let tf;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -506,6 +506,64 @@ describe('index', () => {
     });
   });
 
+  describe('taint', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.taint();
+      td.verify(buildCommand('taint', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.taint();
+      td.verify(buildAndExec('taint', {}));
+    });
+  });
+
+  describe('untaint', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.untaint();
+      td.verify(buildCommand('untaint', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.untaint();
+      td.verify(buildAndExec('untaint', {}));
+    });
+  });
+
   describe('validate', () => {
     let Terrajs;
     let tf;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -245,6 +245,35 @@ describe('index', () => {
     });
   });
 
+  describe('graph', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.graph();
+      td.verify(buildCommand('graph', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.graph();
+      td.verify(buildAndExec('graph', {}));
+    });
+  });
+
   describe('init', () => {
     let Terrajs;
     let tf;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -621,4 +621,149 @@ describe('index', () => {
       td.verify(buildAndExec('version', {}));
     });
   });
+
+  describe('workspaceDelete', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.workspaceDelete();
+      td.verify(buildCommand('workspace-delete', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.workspaceDelete();
+      td.verify(buildAndExec('workspace-delete', {}));
+    });
+  });
+
+  describe('workspaceList', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.workspaceList();
+      td.verify(buildCommand('workspace-list', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.workspaceList();
+      td.verify(buildAndExec('workspace-list', {}));
+    });
+  });
+
+  describe('workspaceNew', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.workspaceNew();
+      td.verify(buildCommand('workspace-new', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.workspaceNew();
+      td.verify(buildAndExec('workspace-new', {}));
+    });
+  });
+
+  describe('workspaceSelect', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.workspaceSelect();
+      td.verify(buildCommand('workspace-select', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.workspaceSelect();
+      td.verify(buildAndExec('workspace-select', {}));
+    });
+  });
+
+  describe('workspaceShow', () => {
+    let Terrajs;
+    let tf;
+    let buildCommand;
+    let buildAndExec;
+
+    beforeEach(() => {
+      td.replace('./registerHelpers');
+      td.replace('./registerPartials');
+      Terrajs = require('./index');
+      tf = new Terrajs();
+      buildCommand = td.replace(tf, 'buildCommand');
+      buildAndExec = td.replace(tf, 'buildAndExec');
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call build command if execute is not set', async () => {
+      tf.execute = false;
+      await tf.workspaceShow();
+      td.verify(buildCommand('workspace-show', {}));
+    });
+
+    it('should call execute command if execute is set', async () => {
+      await tf.workspaceShow();
+      td.verify(buildAndExec('workspace-show', {}));
+    });
+  });
 });

--- a/templates/get.hbs
+++ b/templates/get.hbs
@@ -1,0 +1,4 @@
+{{command}} get
+{{> update }}
+{{> no-color }}
+{{dir}}

--- a/templates/graph.hbs
+++ b/templates/graph.hbs
@@ -1,0 +1,10 @@
+{{command}} graph
+{{> draw-cycles }}
+{{#ifeq version '0.12'}}
+{{> module-depth }}
+{{/ifeq}}
+{{#ifeq version '0.11'}}
+{{> no-color }}
+{{/ifeq}}
+{{> type }}
+{{dir}}

--- a/templates/import.hbs
+++ b/templates/import.hbs
@@ -1,0 +1,14 @@
+{{command}} import
+{{> backup }}
+{{> config }}
+{{> allow-missing-config }}
+{{> input }}
+{{> lock }}
+{{> lock-timeout }}
+{{> no-color }}
+{{> state }}
+{{> state-out }}
+{{> vars }}
+{{> var-files }}
+{{address}}
+{{id}}

--- a/templates/providers.hbs
+++ b/templates/providers.hbs
@@ -1,0 +1,2 @@
+{{command}} providers
+{{dir}}

--- a/templates/refresh.hbs
+++ b/templates/refresh.hbs
@@ -1,0 +1,12 @@
+{{command}} refresh
+{{> backup }}
+{{> input }}
+{{> lock }}
+{{> lock-timeout }}
+{{> no-color}}
+{{> state }}
+{{> state-out }}
+{{> target }}
+{{> vars }}
+{{> var-files }}
+{{dir}}

--- a/templates/show.hbs
+++ b/templates/show.hbs
@@ -1,0 +1,4 @@
+{{command}} show
+{{> module-depth }}
+{{> no-color }}
+{{dir}}

--- a/templates/workspace-delete.hbs
+++ b/templates/workspace-delete.hbs
@@ -1,0 +1,6 @@
+{{command}} workspace delete
+{{> force }}
+{{> lock }}
+{{> lock-timeout }}
+{{name}}
+{{dir}}

--- a/templates/workspace-list.hbs
+++ b/templates/workspace-list.hbs
@@ -1,0 +1,2 @@
+{{command}} workspace list
+{{dir}}

--- a/templates/workspace-new.hbs
+++ b/templates/workspace-new.hbs
@@ -1,0 +1,6 @@
+{{command}} workspace new
+{{> lock }}
+{{> lock-timeout }}
+{{> state }}
+{{name}}
+{{dir}}

--- a/templates/workspace-select.hbs
+++ b/templates/workspace-select.hbs
@@ -1,0 +1,3 @@
+{{command}} workspace select
+{{name}}
+{{dir}}

--- a/templates/workspace-show.hbs
+++ b/templates/workspace-show.hbs
@@ -1,0 +1,1 @@
+{{command}} workspace show


### PR DESCRIPTION
Adds initial support for:

- `import`
- `graph`
- `providers`
- `refresh`
- `show`
- `get`
- `workspace`