### PR TITLE
Add version range support to templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -908,6 +908,14 @@
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "eslint-config-airbnb-base": {
@@ -1916,6 +1924,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-processinfo": {
@@ -2142,6 +2158,14 @@
         "chalk": "^2.4.2"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -2149,6 +2173,14 @@
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "mimic-fn": {
@@ -2977,10 +3009,12 @@
       "dev": true
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -3575,6 +3609,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "debug": "^4.1.1",
     "deepmerge": "^4.2.2",
     "handlebars": "^4.7.6",
+    "semver": "^7.3.5",
     "shelljs": "^0.8.3"
   },
   "devDependencies": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -12,33 +12,6 @@ function ifneq(a, b, opts) {
   return (a !== b) ? opts.fn(this) : opts.inverse(this);
 }
 
-function switchHandlebarHelper(value, opts) {
-  this.switch_value = value;
-  this.switch_break = false;
-  return opts.fn(this);
-}
-
-function caseHandlebarHelper() {
-  /* eslint-disable-next-line prefer-rest-params */
-  const args = Array.prototype.slice.call(arguments);
-  const opts = args.pop();
-  const caseValues = args;
-
-  if (this.switch_break || caseValues.indexOf(this.switch_value) === -1) {
-    return '';
-  }
-
-  if (opts.hash.break === true) {
-    this.switch_break = true;
-  }
-
-  return opts.fn(this);
-}
-
-function defaultHandlebarHelper(opts) {
-  return (!this.switch_break ? opts.fn(this) : '');
-}
-
 function ifArray(value, opts) {
   return (value instanceof Array) ? opts.fn(this) : opts.inverse(this);
 }
@@ -53,9 +26,6 @@ module.exports = {
   includes,
   ifeq,
   ifneq,
-  switchHandlebarHelper,
-  caseHandlebarHelper,
-  defaultHandlebarHelper,
   ifArray,
   ifVersionSatisfies,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,3 +1,5 @@
+const semver = require('semver');
+
 const camelToKebab = (str) => str.split(/(?=[A-Z])/).join('-').toLowerCase();
 const camelToSnake = (str) => str.split(/(?=[A-Z])/).join('_').toLowerCase();
 const includes = (a, b, opts) => (a.includes(b) ? opts.fn(this) : opts.inverse(this));
@@ -41,6 +43,10 @@ function ifArray(value, opts) {
   return (value instanceof Array) ? opts.fn(this) : opts.inverse(this);
 }
 
+function ifVersionSatisfies(version, pattern, opts) {
+  return (semver.satisfies(version, pattern)) ? opts.fn(this) : opts.inverse(this);
+}
+
 module.exports = {
   camelToKebab,
   camelToSnake,
@@ -51,4 +57,5 @@ module.exports = {
   caseHandlebarHelper,
   defaultHandlebarHelper,
   ifArray,
+  ifVersionSatisfies,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,8 +16,8 @@ function ifArray(value, opts) {
   return (value instanceof Array) ? opts.fn(this) : opts.inverse(this);
 }
 
-function ifVersionSatisfies(version, pattern, opts) {
-  return (semver.satisfies(version, pattern)) ? opts.fn(this) : opts.inverse(this);
+function ifVersionSatisfies(version, range, opts) {
+  return (semver.satisfies(version, range)) ? opts.fn(this) : opts.inverse(this);
 }
 
 module.exports = {

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -8,6 +8,7 @@ const {
   includes,
   ifeq,
   ifneq,
+  ifVersionSatisfies,
 } = require('./helpers');
 
 describe('helpers', () => {
@@ -81,6 +82,26 @@ describe('helpers', () => {
 
     it('should call inverse function if values match', () => {
       ifneq('a', 'a', opts);
+      td.verify(opts.inverse(td.matchers.isA(Object)), { times: 1 });
+    });
+  });
+
+  describe('ifVersionSatisfies', () => {
+    const opts = {};
+    beforeEach(() => {
+      opts.fn = td.function();
+      opts.inverse = td.function();
+    });
+
+    afterEach(() => td.reset());
+
+    it('should call fn function if version is within the range', () => {
+      ifVersionSatisfies('0.11.14', '<0.12', opts);
+      td.verify(opts.fn(td.matchers.isA(Object)), { times: 1 });
+    });
+
+    it('should call inverse function if version is outside of the range', () => {
+      ifVersionSatisfies('0.11.14', '>=0.12', opts);
       td.verify(opts.inverse(td.matchers.isA(Object)), { times: 1 });
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,10 @@ class Terrajs {
   }
 
   async getTerraformVersion() {
-    const response = await shExec(`${this.command} -version`, { silent: true });
+    const response = await shExec(`${this.command} -version`, {
+      env: { CHECKPOINT_DISABLE: 1 },
+      silent: true,
+    });
     return response.split('v')[1].trim();
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ class Terrajs {
 
   async getTerraformVersion() {
     const response = await shExec(`${this.command} -version`, { silent: true });
-    return response.split('v')[1].split('.').slice(0, 2).join('.');
+    return response.split('v')[1].trim();
   }
 
   async buildCommand(action, args) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -96,9 +96,9 @@ describe('index', () => {
 
     afterEach(() => td.reset());
 
-    it('should return the version string as "Major.Minor"', async () => {
+    it('should return the version string', async () => {
       const result = await tf.getTerraformVersion();
-      assert.strictEqual(result, '0.12');
+      assert.strictEqual(result, '0.12.15');
     });
   });
 

--- a/src/integration-0.11.test.js
+++ b/src/integration-0.11.test.js
@@ -10,7 +10,7 @@ describe('integration (Terraform 0.11)', () => {
   beforeEach(() => {
     tf = new Terrajs({ execute: false });
     td.replace(tf, 'getTerraformVersion');
-    td.when(tf.getTerraformVersion()).thenReturn('0.11');
+    td.when(tf.getTerraformVersion()).thenReturn('0.11.0');
   });
 
   afterEach(() => td.reset());

--- a/src/integration-0.12.test.js
+++ b/src/integration-0.12.test.js
@@ -10,7 +10,7 @@ describe('integration (Terraform 0.12)', () => {
   beforeEach(() => {
     tf = new Terrajs({ execute: false });
     td.replace(tf, 'getTerraformVersion');
-    td.when(tf.getTerraformVersion()).thenReturn('0.12');
+    td.when(tf.getTerraformVersion()).thenReturn('0.12.0');
   });
 
   afterEach(() => td.reset());

--- a/src/integration-0.13.test.js
+++ b/src/integration-0.13.test.js
@@ -10,7 +10,7 @@ describe('integration (Terraform 0.13)', () => {
   beforeEach(() => {
     tf = new Terrajs({ execute: false });
     td.replace(tf, 'getTerraformVersion');
-    td.when(tf.getTerraformVersion()).thenReturn('0.13');
+    td.when(tf.getTerraformVersion()).thenReturn('0.13.0');
   });
 
   afterEach(() => td.reset());

--- a/src/registerHelpers.js
+++ b/src/registerHelpers.js
@@ -2,25 +2,19 @@ const Handlebars = require('handlebars');
 const {
   camelToKebab,
   camelToSnake,
-  includes,
+  ifArray,
   ifeq,
   ifneq,
-  switchHandlebarHelper,
-  caseHandlebarHelper,
-  defaultHandlebarHelper,
-  ifArray,
   ifVersionSatisfies,
+  includes,
 } = require('./helpers');
 
 module.exports = () => {
   Handlebars.registerHelper('camelToKebab', camelToKebab);
   Handlebars.registerHelper('camelToSnake', camelToSnake);
-  Handlebars.registerHelper('includes', includes);
+  Handlebars.registerHelper('ifArray', ifArray);
   Handlebars.registerHelper('ifeq', ifeq);
   Handlebars.registerHelper('ifneq', ifneq);
-  Handlebars.registerHelper('switch', switchHandlebarHelper);
-  Handlebars.registerHelper('case', caseHandlebarHelper);
-  Handlebars.registerHelper('default', defaultHandlebarHelper);
-  Handlebars.registerHelper('ifArray', ifArray);
   Handlebars.registerHelper('ifVersionSatisfies', ifVersionSatisfies);
+  Handlebars.registerHelper('includes', includes);
 };

--- a/src/registerHelpers.js
+++ b/src/registerHelpers.js
@@ -9,6 +9,7 @@ const {
   caseHandlebarHelper,
   defaultHandlebarHelper,
   ifArray,
+  ifVersionSatisfies,
 } = require('./helpers');
 
 module.exports = () => {
@@ -21,4 +22,5 @@ module.exports = () => {
   Handlebars.registerHelper('case', caseHandlebarHelper);
   Handlebars.registerHelper('default', defaultHandlebarHelper);
   Handlebars.registerHelper('ifArray', ifArray);
+  Handlebars.registerHelper('ifVersionSatisfies', ifVersionSatisfies);
 };

--- a/src/registerHelpers.test.js
+++ b/src/registerHelpers.test.js
@@ -17,6 +17,6 @@ describe('registerHelpers', () => {
 
   it('should call exec with the correct arguments', () => {
     registerHelpers();
-    td.verify(registerHelper(td.matchers.isA(String), td.matchers.isA(Function)), { times: 9 });
+    td.verify(registerHelper(td.matchers.isA(String), td.matchers.isA(Function)), { times: 10 });
   });
 });

--- a/src/registerHelpers.test.js
+++ b/src/registerHelpers.test.js
@@ -17,6 +17,6 @@ describe('registerHelpers', () => {
 
   it('should call exec with the correct arguments', () => {
     registerHelpers();
-    td.verify(registerHelper(td.matchers.isA(String), td.matchers.isA(Function)), { times: 10 });
+    td.verify(registerHelper(td.matchers.isA(String), td.matchers.isA(Function)), { times: 7 });
   });
 });

--- a/templates/fmt.hbs
+++ b/templates/fmt.hbs
@@ -3,8 +3,8 @@
 {{> write }}
 {{> diff }}
 {{> check }}
-{{#ifeq version '0.12'}}
+{{#ifVersionSatisfies version '>=0.12'}}
 {{> no-color }}
 {{> recursive }}
-{{/ifeq}}
+{{/ifVersionSatisfies}}
 {{dir}}

--- a/templates/graph.hbs
+++ b/templates/graph.hbs
@@ -1,10 +1,10 @@
 {{command}} graph
 {{> draw-cycles }}
-{{#ifeq version '0.12'}}
+{{#ifVersionSatisfies version '>=0.12'}}
 {{> module-depth }}
-{{/ifeq}}
-{{#ifeq version '0.11'}}
+{{/ifVersionSatisfies}}
+{{#ifVersionSatisfies version '<0.12'}}
 {{> no-color }}
-{{/ifeq}}
+{{/ifVersionSatisfies}}
 {{> type }}
 {{dir}}

--- a/templates/graph.hbs
+++ b/templates/graph.hbs
@@ -1,10 +1,9 @@
 {{command}} graph
 {{> draw-cycles }}
-{{#ifVersionSatisfies version '>=0.12'}}
-{{> module-depth }}
-{{/ifVersionSatisfies}}
 {{#ifVersionSatisfies version '<0.12'}}
 {{> no-color }}
+{{else}}
+{{> module-depth }}
 {{/ifVersionSatisfies}}
 {{> type }}
 {{dir}}

--- a/templates/output.hbs
+++ b/templates/output.hbs
@@ -1,7 +1,7 @@
 {{command}} output
 {{> state }}
 {{> no-color }}
-{{#ifeq version '0.11'}}
+{{#ifVersionSatisfies version '<0.12'}}
 {{> module }}
-{{/ifeq}}
+{{/ifVersionSatisfies}}
 {{> json }}

--- a/templates/plan.hbs
+++ b/templates/plan.hbs
@@ -4,9 +4,9 @@
 {{> input }}
 {{> lock }}
 {{> lock-timeout }}
-{{#ifeq version '0.11'}}
+{{#ifVersionSatisfies version '<0.12'}}
 {{> module-depth }}
-{{/ifeq}}
+{{/ifVersionSatisfies}}
 {{> no-color}}
 {{> out }}
 {{> parallelism }}

--- a/templates/validate.hbs
+++ b/templates/validate.hbs
@@ -1,10 +1,9 @@
 {{command}} validate
-{{#ifVersionSatisfies version '>=0.12'}}
-{{> json }}
-{{/ifVersionSatisfies}}
 {{#ifVersionSatisfies version '<0.12'}}
 {{> check-variables }}
 {{> vars }}
 {{> var-files }}
+{{else}}
+{{> json }}
 {{/ifVersionSatisfies}}
 {{> no-color }}

--- a/templates/validate.hbs
+++ b/templates/validate.hbs
@@ -1,13 +1,10 @@
 {{command}} validate
-
-{{#switch version}}
-  {{#case "0.12"}}
+{{#ifVersionSatisfies version '>=0.12'}}
 {{> json }}
-  {{/case}}
-  {{#case "0.11"}}
+{{/ifVersionSatisfies}}
+{{#ifVersionSatisfies version '<0.12'}}
 {{> check-variables }}
 {{> vars }}
 {{> var-files }}
-  {{/case}}
-{{/switch}}
+{{/ifVersionSatisfies}}
 {{> no-color }}


### PR DESCRIPTION
Adds version range support to templates through the `semver` package to replace the use of clunky switch/case helpers. Allows us to use a variety of different ranges as described [here](https://github.com/npm/node-semver#usage) to be as precise as we need to be.

This will give more flexibility as Terraform changes over time.