### PR TITLE
Add a check for booleans when parsing variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cda0/terrajs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cda0/terrajs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A node interface to Terraform",
   "main": "src/index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -43,6 +43,10 @@ function parseVariable(key, value) {
     return `'${parsedKey}=${parsedValue.replace(/'/g, '\\\'')}'`;
   }
 
+  if (typeof value === 'boolean') {
+    return `"${parsedKey}=${value}"`;
+  }
+
   // Double-quotes can prematurely close the string, so they need to be escaped.
   return `"${parsedKey}=${value.replace(/"/g, '\\"')}"`;
 }


### PR DESCRIPTION
Didn't check for bools before, so they'd fail when trying to call `replace()` on them.