### PR TITLE
Fix shelljs excluding Path changes from version command

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,10 @@ class Terrajs {
 
   async getTerraformVersion() {
     const response = await shExec(`${this.command} -version`, {
-      env: { CHECKPOINT_DISABLE: 1 },
+      env: {
+        ...process.env,
+        CHECKPOINT_DISABLE: 1,
+      },
       silent: true,
     });
     return response.split('v')[1].trim();


### PR DESCRIPTION
I forgot that `shelljs`/`child_process` will exclude everything in the environment when you make a single addition. By turning off the version check, I broke this for users who have Terraform version switchers (tfenv, tfswitch) which rely on changes to the `PATH` to find their Terraform binaries. This change includes everything in the environment before making the addition.

I did not bump the version here as I'd like this to go in before #30 which includes a bump. I'll release both fixes in `0.5.2`.